### PR TITLE
Updated room message logic

### DIFF
--- a/globals.js
+++ b/globals.js
@@ -21,6 +21,16 @@ global.socketInRoom = function (roomId, socketId) {
   return ioRoom && socketId in ioRoom.sockets;
 };
 
+// method for sending a message to all players in a room, except one.
+// using the io.send instead of relying on the "sender" socket.
+global.roomMessage = function (roomId, message, exclude) {
+  const ioRoom = global.io.sockets.adapter.rooms[roomId];
+  for (let socketId in ioRoom) {
+    if (Array.isArray(exclude) && exclude.includes(socketId)) continue;
+    ioRoom[socketId].emit('output', { message: message });
+  }
+};
+
 global.GetSocketByUsername = (username) => {
   const sockets = Object.keys(global.io.sockets.sockets);
   let socket = null;
@@ -46,7 +56,6 @@ global.GetSocketByUserId = (userId) => {
   });
   return socket;
 };
-
 
 global.getRandomNumber = function (min, max) {
   return Math.floor(Math.random() * (Math.floor(max) - Math.ceil(min))) + min;

--- a/models/mob.js
+++ b/models/mob.js
@@ -133,7 +133,7 @@ Mob.prototype.attack = function (now) {
   }
 
   playerSocket.emit('output', { message: playerMessage });
-  global.io.to(playerSocket.user.roomId).emit('output', { message: roomMessage });
+  global.roomMessage(this.roomId, roomMessage, [playerSocket.id]);
 
   return true;
 };


### PR DESCRIPTION
Updated room messages to not rely on player socket to send messages to a room. Any mob attempting an action on a disconnected player will still be able to send messages to the rest of the players in the room.